### PR TITLE
feat: Add @AssertDefault annotation for field-level default assertions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,7 @@ mvn package -DskipTests        # Build JAR
 | Concept | Description |
 |---------|-------------|
 | `@Assertable` | Annotation on domain classes, generates `XxxAssert` builder |
+| `@AssertDefault` | Field annotation — auto-asserts default value in `created().verify()` unless explicitly overridden |
 | `ignoredFields` | Fields auto-skipped in assertions (audit, version, timestamps) |
 | `takeSnapshot()` | Captures DB state BEFORE action + activates usage tracking |
 | `assertEntityWithSnapshot()` | Asserts only changed fields against snapshot |
@@ -36,14 +37,14 @@ mvn package -DskipTests        # Build JAR
 ## Generated Builder API
 
 ```java
-// Assert new/created object - must cover ALL fields
+// Assert new/created object - must cover ALL fields (unless @AssertDefault handles them)
 OrderAssert.created(order)
     .id_is_not_null()
     .status_is("PENDING")
     .customerId_is(customerId)
     .total_is(new BigDecimal("99.99"))
     .notes_is_empty()          // Optional.empty()
-    .verify();
+    .verify();                 // @AssertDefault fields auto-asserted here
 
 // Assert entity changes against snapshot - only specify CHANGED fields
 OrderAssert.updated(order)
@@ -61,6 +62,7 @@ OrderAssert.deleted(order).verify();
 |------------|---------|
 | `T field` | `field_is(T)`, `field_is_null()`, `field_is_not_null()`, `field_is_ignored()` |
 | `Optional<T>` | Above + `field_is_empty()`, `field_is_not_empty()`, `field_is(InnerT)` |
+| `@AssertDefault` field | Same as above; default auto-asserted in `verify()` unless explicitly set |
 
 ## Test Class Setup
 
@@ -173,6 +175,8 @@ public class Order {
     private String status;
     private BigDecimal total;
     private Optional<String> notes;
+    @AssertDefault("false")
+    private Boolean archived;      // Auto-asserted as false in created().verify()
     private Long version;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -23,7 +23,7 @@ AI-actionable instructions for migrating from Fabut 4.x to 5.x.
 <version>4.x.x</version>
 
 <!-- New -->
-<version>5.5.1-RELEASE</version>
+<version>5.6.0-RELEASE</version>
 ```
 
 ### Step 2: Remove PropertyPath Imports
@@ -250,7 +250,7 @@ void testUpdateUser() {
 
 ## Checklist
 
-- [ ] Update pom.xml dependency to 5.5.1-RELEASE
+- [ ] Update pom.xml dependency to 5.6.0-RELEASE
 - [ ] Delete `PropertyPath` imports from all files
 - [ ] Replace `Entity.CONSTANT` with `"camelCase"` strings in test assertions
 - [ ] Replace `assertThat()` with `created()`, `assertSnapshot()` with `updated()`

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ void testCreateOrder() {
 - **Complete coverage** - Fabut fails if you forget to assert a field
 - **Minimal boilerplate** - Just `created(object)` - no need to pass `this`
 - **Optional support** - First-class support for `Optional<T>` fields
+- **Default assertions** - Declare field defaults with `@AssertDefault` — no need to assert them in every test
 - **Auto-ignore fields** - Mark audit fields as ignored once, never think about them again
 - **Snapshot testing** - Track database changes automatically
 - **Usage tracking** - Detect suboptimal data fetching with automatic field-level access analysis
@@ -56,7 +57,7 @@ void testCreateOrder() {
 <dependency>
     <groupId>cloud.alchemy</groupId>
     <artifactId>fabut</artifactId>
-    <version>5.5.1-RELEASE</version>
+    <version>5.6.0-RELEASE</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -243,6 +244,59 @@ void createProduct_setsNameAndPrice() {
         .verify();
 }
 ```
+
+### Default Assertions
+
+Fields annotated with `@AssertDefault` are automatically asserted when `verify()` is called on a `created()` builder, unless you explicitly assert them:
+
+```java
+@Assertable(ignoredFields = {"version"})
+public class Order {
+    private Long id;
+    private String status;
+    @AssertDefault("false")
+    private Boolean archived;
+    @AssertDefault("empty")
+    private Optional<String> notes;
+    private Long version;
+    // getters...
+}
+
+@Test
+void createOrder_defaultFieldsAutoAsserted() {
+    Order order = orderService.create(customerId);
+
+    // archived=false and notes=empty are auto-asserted by @AssertDefault
+    OrderAssert.created(order)
+        .id_is_not_null()
+        .status_is("PENDING")
+        .verify();  // archived and notes defaults checked automatically
+}
+
+@Test
+void createOrder_overrideDefault() {
+    Order order = orderService.createArchived(customerId);
+
+    // Explicit assertion overrides the default
+    OrderAssert.created(order)
+        .id_is_not_null()
+        .status_is("PENDING")
+        .archived_is(true)       // Override @AssertDefault("false")
+        .notes_is("Auto-archived")
+        .verify();
+}
+```
+
+Supported `@AssertDefault` values:
+
+| Value | Valid on | Behavior |
+|-------|----------|----------|
+| `"true"` / `"false"` | `Boolean`, `boolean`, `Optional<Boolean>` | Asserts boolean value |
+| `"empty"` | `Optional<?>` | Asserts `Optional.empty()` |
+| `"null"` | Any reference type | Asserts `null` |
+| Numeric string | Numeric types, `Optional<NumericType>` | Asserts numeric value |
+
+Invalid combinations (e.g. `@AssertDefault("false")` on a `String` field) produce compile-time errors.
 
 ## Generated Methods Reference
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>cloud.alchemy</groupId>
     <artifactId>fabut</artifactId>
-    <version>5.5.1-RELEASE</version>
+    <version>5.6.0-RELEASE</version>
     <packaging>jar</packaging>
 
     <name>Alchemy Fabut</name>

--- a/src/main/java/cloud/alchemy/fabut/annotation/AssertDefault.java
+++ b/src/main/java/cloud/alchemy/fabut/annotation/AssertDefault.java
@@ -1,0 +1,43 @@
+package cloud.alchemy.fabut.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Declares the default expected value for a field in generated assertion builders.
+ * When {@code verify()} is called on a {@code created()} assertion and this field
+ * has not been explicitly asserted, the default value is automatically asserted.
+ *
+ * <p>Supported values:</p>
+ * <ul>
+ *   <li>{@code "true"}, {@code "false"} — Boolean fields</li>
+ *   <li>{@code "empty"} — Optional.empty()</li>
+ *   <li>{@code "null"} — null value</li>
+ * </ul>
+ *
+ * <p>For Optional fields, non-special values are wrapped in {@code Optional.of()}.</p>
+ *
+ * <p>Usage:</p>
+ * <pre>
+ * {@literal @}Assertable
+ * public class PropertyValue {
+ *     {@literal @}AssertDefault("false")
+ *     private Boolean usedInCoa;
+ * }
+ *
+ * // Before: PropertyValueAssert.created(pv).usedInCoa_is(false).verify();
+ * // After:  PropertyValueAssert.created(pv).verify();  // usedInCoa=false is automatic
+ * </pre>
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.SOURCE)
+public @interface AssertDefault {
+
+    /**
+     * The default expected value as a string literal.
+     * Interpreted based on the field's type.
+     */
+    String value();
+}

--- a/src/main/java/cloud/alchemy/fabut/processor/AssertableProcessor.java
+++ b/src/main/java/cloud/alchemy/fabut/processor/AssertableProcessor.java
@@ -1,5 +1,6 @@
 package cloud.alchemy.fabut.processor;
 
+import cloud.alchemy.fabut.annotation.AssertDefault;
 import cloud.alchemy.fabut.annotation.AssertGroup;
 import cloud.alchemy.fabut.annotation.Assertable;
 
@@ -101,6 +102,9 @@ public class AssertableProcessor extends AbstractProcessor {
     private List<FieldInfo> collectFieldsRecursive(TypeElement typeElement, Set<String> ignoredFields, Set<String> seenFieldNames) {
         List<FieldInfo> fields = new ArrayList<>();
 
+        // Collect @AssertDefault annotations from field declarations
+        Map<String, String> fieldDefaults = collectFieldDefaults(typeElement);
+
         // Get all methods (including inherited)
         for (Element enclosed : typeElement.getEnclosedElements()) {
             if (enclosed.getKind() == ElementKind.METHOD) {
@@ -117,8 +121,9 @@ public class AssertableProcessor extends AbstractProcessor {
                         boolean isOptional = isOptionalType(returnType);
                         String typeString = getTypeString(returnType);
                         String innerTypeString = isOptional ? getOptionalInnerType(returnType) : typeString;
+                        String defaultValue = fieldDefaults.get(fieldName);
 
-                        fields.add(new FieldInfo(fieldName, typeString, innerTypeString, isOptional));
+                        fields.add(new FieldInfo(fieldName, typeString, innerTypeString, isOptional, defaultValue));
                         seenFieldNames.add(fieldName);
                     }
                 }
@@ -137,6 +142,23 @@ public class AssertableProcessor extends AbstractProcessor {
         }
 
         return fields;
+    }
+
+    /**
+     * Scan field declarations in the type for @AssertDefault annotations.
+     * Returns a map of fieldName → default value string.
+     */
+    private Map<String, String> collectFieldDefaults(TypeElement typeElement) {
+        Map<String, String> defaults = new HashMap<>();
+        for (Element enclosed : typeElement.getEnclosedElements()) {
+            if (enclosed.getKind() == ElementKind.FIELD) {
+                AssertDefault assertDefault = enclosed.getAnnotation(AssertDefault.class);
+                if (assertDefault != null) {
+                    defaults.put(enclosed.getSimpleName().toString(), assertDefault.value());
+                }
+            }
+        }
+        return defaults;
     }
 
     private boolean isGetter(ExecutableElement method) {
@@ -193,12 +215,20 @@ public class AssertableProcessor extends AbstractProcessor {
             out.println();
         }
 
+        boolean hasDefaults = fields.stream().anyMatch(f -> f.defaultValue != null);
+
         // Imports
         out.println("import cloud.alchemy.fabut.Fabut;");
         out.println("import cloud.alchemy.fabut.property.IProperty;");
         out.println("import java.util.ArrayList;");
+        if (hasDefaults) {
+            out.println("import java.util.HashSet;");
+        }
         out.println("import java.util.List;");
         out.println("import java.util.Optional;");
+        if (hasDefaults) {
+            out.println("import java.util.Set;");
+        }
         out.println();
 
         // Class javadoc
@@ -216,6 +246,9 @@ public class AssertableProcessor extends AbstractProcessor {
         out.println("    private final boolean isSnapshot;");
         out.println("    private final boolean isDelete;");
         out.println("    private final List<IProperty> properties = new ArrayList<>();");
+        if (hasDefaults) {
+            out.println("    private final Set<String> explicitFields = new HashSet<>();");
+        }
         out.println();
 
         // Constructor - auto-adds ignored() for fields specified in @Assertable(ignoredFields)
@@ -309,6 +342,9 @@ public class AssertableProcessor extends AbstractProcessor {
             out.println("    public static " + builderClassName + " created(" + params + ") {");
             out.println("        " + builderClassName + " builder = new " + builderClassName + "(Fabut.current(), object, false);");
             for (FieldInfo field : mandatoryFields) {
+                if (hasDefaults) {
+                    out.println("        builder.explicitFields.add(\"" + field.name + "\");");
+                }
                 out.println("        builder.properties.add(builder.fabut.value(\"" + field.name + "\", " + field.name + "));");
             }
             out.println("        return builder;");
@@ -327,6 +363,9 @@ public class AssertableProcessor extends AbstractProcessor {
             out.println("    public static " + builderClassName + " created(" + paramsWithFabut + ") {");
             out.println("        " + builderClassName + " builder = new " + builderClassName + "(fabut, object, false);");
             for (FieldInfo field : mandatoryFields) {
+                if (hasDefaults) {
+                    out.println("        builder.explicitFields.add(\"" + field.name + "\");");
+                }
                 out.println("        builder.properties.add(builder.fabut.value(\"" + field.name + "\", " + field.name + "));");
             }
             out.println("        return builder;");
@@ -341,6 +380,9 @@ public class AssertableProcessor extends AbstractProcessor {
             out.println("    public static " + builderClassName + " updated(" + params.toString().replace("object", "entity") + ") {");
             out.println("        " + builderClassName + " builder = new " + builderClassName + "(Fabut.current(), entity, true);");
             for (FieldInfo field : mandatoryFields) {
+                if (hasDefaults) {
+                    out.println("        builder.explicitFields.add(\"" + field.name + "\");");
+                }
                 out.println("        builder.properties.add(builder.fabut.value(\"" + field.name + "\", " + field.name + "));");
             }
             out.println("        return builder;");
@@ -353,6 +395,9 @@ public class AssertableProcessor extends AbstractProcessor {
             out.println("    public static " + builderClassName + " updated(" + paramsWithFabut.toString().replace("object", "entity") + ") {");
             out.println("        " + builderClassName + " builder = new " + builderClassName + "(fabut, entity, true);");
             for (FieldInfo field : mandatoryFields) {
+                if (hasDefaults) {
+                    out.println("        builder.explicitFields.add(\"" + field.name + "\");");
+                }
                 out.println("        builder.properties.add(builder.fabut.value(\"" + field.name + "\", " + field.name + "));");
             }
             out.println("        return builder;");
@@ -368,17 +413,17 @@ public class AssertableProcessor extends AbstractProcessor {
 
         // Generate created methods for each newGroup
         for (AssertGroup group : create) {
-            generateGroupMethods(out, className, builderClassName, group, fieldMap, "created", "object", false);
+            generateGroupMethods(out, className, builderClassName, group, fieldMap, "created", "object", false, hasDefaults);
         }
 
         // Generate updated methods for each updateGroup
         for (AssertGroup group : update) {
-            generateGroupMethods(out, className, builderClassName, group, fieldMap, "updated", "entity", true);
+            generateGroupMethods(out, className, builderClassName, group, fieldMap, "updated", "entity", true, hasDefaults);
         }
 
         // Generate methods for each field
         for (FieldInfo field : fields) {
-            generateFieldMethods(out, builderClassName, field);
+            generateFieldMethods(out, builderClassName, field, hasDefaults);
         }
 
         // Verify method
@@ -391,6 +436,21 @@ public class AssertableProcessor extends AbstractProcessor {
         out.println("            fabut.assertEntityAsDeleted(object);");
         out.println("            return object;");
         out.println("        }");
+
+        // Generate defaults block for created assertions (non-snapshot)
+        List<FieldInfo> fieldsWithDefaults = fields.stream()
+                .filter(f -> f.defaultValue != null)
+                .toList();
+        if (!fieldsWithDefaults.isEmpty()) {
+            out.println("        if (!isSnapshot) {");
+            for (FieldInfo field : fieldsWithDefaults) {
+                out.println("            if (!explicitFields.contains(\"" + field.name + "\")) {");
+                out.println("                properties.add(" + generateDefaultPropertyExpression(field) + ");");
+                out.println("            }");
+            }
+            out.println("        }");
+        }
+
         out.println("        IProperty[] props = properties.toArray(new IProperty[0]);");
         out.println("        if (isSnapshot) {");
         out.println("            return fabut.assertEntityWithSnapshot(object, props);");
@@ -403,12 +463,15 @@ public class AssertableProcessor extends AbstractProcessor {
         out.println("}");
     }
 
-    private void generateFieldMethods(PrintWriter out, String builderClassName, FieldInfo field) {
+    private void generateFieldMethods(PrintWriter out, String builderClassName, FieldInfo field, boolean hasDefaults) {
         String fieldPath = "\"" + field.name + "\"";
+        // Track explicit fields only when defaults exist (to avoid unnecessary overhead)
+        String trackExplicit = hasDefaults ? "        explicitFields.add(" + fieldPath + ");\n" : "";
 
         // field_is(value) - exact value match
         out.println("    /** Assert " + field.name + " equals the expected value. */");
         out.println("    public " + builderClassName + " " + field.name + "_is(" + field.type + " expected) {");
+        out.print(trackExplicit);
         out.println("        properties.add(fabut.value(" + fieldPath + ", expected));");
         out.println("        return this;");
         out.println("    }");
@@ -417,6 +480,7 @@ public class AssertableProcessor extends AbstractProcessor {
         // field_is_null()
         out.println("    /** Assert " + field.name + " is null. */");
         out.println("    public " + builderClassName + " " + field.name + "_is_null() {");
+        out.print(trackExplicit);
         out.println("        properties.add(fabut.isNull(" + fieldPath + "));");
         out.println("        return this;");
         out.println("    }");
@@ -425,6 +489,7 @@ public class AssertableProcessor extends AbstractProcessor {
         // field_is_not_null()
         out.println("    /** Assert " + field.name + " is not null. */");
         out.println("    public " + builderClassName + " " + field.name + "_is_not_null() {");
+        out.print(trackExplicit);
         out.println("        properties.add(fabut.notNull(" + fieldPath + "));");
         out.println("        return this;");
         out.println("    }");
@@ -433,6 +498,7 @@ public class AssertableProcessor extends AbstractProcessor {
         // field_is_ignored()
         out.println("    /** Ignore " + field.name + " in this assertion. */");
         out.println("    public " + builderClassName + " " + field.name + "_is_ignored() {");
+        out.print(trackExplicit);
         out.println("        properties.add(fabut.ignored(" + fieldPath + "));");
         out.println("        return this;");
         out.println("    }");
@@ -442,6 +508,7 @@ public class AssertableProcessor extends AbstractProcessor {
         if (field.isOptional) {
             out.println("    /** Assert " + field.name + " is empty (Optional.empty()). */");
             out.println("    public " + builderClassName + " " + field.name + "_is_empty() {");
+            out.print(trackExplicit);
             out.println("        properties.add(fabut.isEmpty(" + fieldPath + "));");
             out.println("        return this;");
             out.println("    }");
@@ -449,6 +516,7 @@ public class AssertableProcessor extends AbstractProcessor {
 
             out.println("    /** Assert " + field.name + " is not empty (Optional has value). */");
             out.println("    public " + builderClassName + " " + field.name + "_is_not_empty() {");
+            out.print(trackExplicit);
             out.println("        properties.add(fabut.notEmpty(" + fieldPath + "));");
             out.println("        return this;");
             out.println("    }");
@@ -457,6 +525,7 @@ public class AssertableProcessor extends AbstractProcessor {
             // Convenience overload: field_is(InnerType) wraps in Optional.of()
             out.println("    /** Assert " + field.name + " contains the expected value (wraps in Optional.of). */");
             out.println("    public " + builderClassName + " " + field.name + "_is(" + field.innerType + " expected) {");
+            out.print(trackExplicit);
             out.println("        properties.add(fabut.value(" + fieldPath + ", Optional.of(expected)));");
             out.println("        return this;");
             out.println("    }");
@@ -466,7 +535,8 @@ public class AssertableProcessor extends AbstractProcessor {
 
     private void generateGroupMethods(PrintWriter out, String className, String builderClassName,
                                        AssertGroup group, Map<String, FieldInfo> fieldMap,
-                                       String methodPrefix, String paramName, boolean isSnapshot) {
+                                       String methodPrefix, String paramName, boolean isSnapshot,
+                                       boolean hasDefaults) {
         String groupName = group.name();
         String[] groupFields = group.fields();
 
@@ -498,6 +568,9 @@ public class AssertableProcessor extends AbstractProcessor {
             for (int i = 0; i < groupFieldInfos.size(); i++) {
                 FieldInfo fieldInfo = groupFieldInfos.get(i);
                 String fieldName = groupFields[i];
+                if (hasDefaults) {
+                    out.println("        builder.explicitFields.add(\"" + fieldName + "\");");
+                }
                 if (fieldInfo.isOptional) {
                     out.println("        builder.properties.add(builder.fabut.value(\"" + fieldName + "\", Optional.ofNullable(" + fieldName + ")));");
                 } else {
@@ -526,6 +599,9 @@ public class AssertableProcessor extends AbstractProcessor {
             for (int i = 0; i < groupFieldInfos.size(); i++) {
                 FieldInfo fieldInfo = groupFieldInfos.get(i);
                 String fieldName = groupFields[i];
+                if (hasDefaults) {
+                    out.println("        builder.explicitFields.add(\"" + fieldName + "\");");
+                }
                 if (fieldInfo.isOptional) {
                     out.println("        builder.properties.add(builder.fabut.value(\"" + fieldName + "\", Optional.ofNullable(" + fieldName + ")));");
                 } else {
@@ -655,5 +731,53 @@ public class AssertableProcessor extends AbstractProcessor {
         out.println("}");
     }
 
-    private record FieldInfo(String name, String type, String innerType, boolean isOptional) {}
+    /**
+     * Generate the Java expression for a default property assertion.
+     * Interprets the @AssertDefault value based on the field's type.
+     */
+    private String generateDefaultPropertyExpression(FieldInfo field) {
+        String value = field.defaultValue;
+        String fieldPath = "\"" + field.name + "\"";
+
+        // Special keywords
+        if ("null".equals(value)) {
+            return "fabut.isNull(" + fieldPath + ")";
+        }
+        if ("empty".equals(value)) {
+            return "fabut.isEmpty(" + fieldPath + ")";
+        }
+
+        // Boolean values
+        if ("true".equals(value) || "false".equals(value)) {
+            if (field.isOptional) {
+                return "fabut.value(" + fieldPath + ", Optional.of(" + value + "))";
+            }
+            return "fabut.value(" + fieldPath + ", " + value + ")";
+        }
+
+        // Numeric values — try integer first, then decimal
+        try {
+            Long.parseLong(value);
+            if (field.isOptional) {
+                return "fabut.value(" + fieldPath + ", Optional.of(" + value + "))";
+            }
+            return "fabut.value(" + fieldPath + ", " + value + ")";
+        } catch (NumberFormatException ignored) {}
+
+        try {
+            Double.parseDouble(value);
+            if (field.isOptional) {
+                return "fabut.value(" + fieldPath + ", Optional.of(" + value + "))";
+            }
+            return "fabut.value(" + fieldPath + ", " + value + ")";
+        } catch (NumberFormatException ignored) {}
+
+        // String literal fallback
+        if (field.isOptional) {
+            return "fabut.value(" + fieldPath + ", Optional.of(\"" + value + "\"))";
+        }
+        return "fabut.value(" + fieldPath + ", \"" + value + "\")";
+    }
+
+    private record FieldInfo(String name, String type, String innerType, boolean isOptional, String defaultValue) {}
 }

--- a/src/main/java/cloud/alchemy/fabut/processor/AssertableProcessor.java
+++ b/src/main/java/cloud/alchemy/fabut/processor/AssertableProcessor.java
@@ -147,6 +147,7 @@ public class AssertableProcessor extends AbstractProcessor {
     /**
      * Scan field declarations in the type for @AssertDefault annotations.
      * Returns a map of fieldName → default value string.
+     * Validates that the default value is compatible with the field's type.
      */
     private Map<String, String> collectFieldDefaults(TypeElement typeElement) {
         Map<String, String> defaults = new HashMap<>();
@@ -154,11 +155,102 @@ public class AssertableProcessor extends AbstractProcessor {
             if (enclosed.getKind() == ElementKind.FIELD) {
                 AssertDefault assertDefault = enclosed.getAnnotation(AssertDefault.class);
                 if (assertDefault != null) {
-                    defaults.put(enclosed.getSimpleName().toString(), assertDefault.value());
+                    String value = assertDefault.value();
+                    String fieldType = enclosed.asType().toString();
+                    boolean isOptional = fieldType.startsWith("java.util.Optional");
+                    String innerType = isOptional ? getOptionalInnerTypeString(fieldType) : fieldType;
+
+                    validateAssertDefaultValue(enclosed, value, fieldType, innerType, isOptional);
+
+                    defaults.put(enclosed.getSimpleName().toString(), value);
                 }
             }
         }
         return defaults;
+    }
+
+    /**
+     * Validate that @AssertDefault value is compatible with the field's type.
+     */
+    private void validateAssertDefaultValue(Element field, String value, String fieldType,
+                                             String innerType, boolean isOptional) {
+        // "null" is valid on any reference type
+        if ("null".equals(value)) {
+            return;
+        }
+
+        // "empty" is only valid on Optional
+        if ("empty".equals(value)) {
+            if (!isOptional) {
+                messager.printMessage(Diagnostic.Kind.ERROR,
+                        "@AssertDefault(\"empty\") can only be used on Optional fields, but field type is " + fieldType, field);
+            }
+            return;
+        }
+
+        // "true"/"false" valid only on Boolean/boolean/Optional<Boolean>
+        if ("true".equals(value) || "false".equals(value)) {
+            String checkType = isOptional ? innerType : fieldType;
+            if (!isBooleanType(checkType)) {
+                messager.printMessage(Diagnostic.Kind.ERROR,
+                        "@AssertDefault(\"" + value + "\") can only be used on Boolean fields, but field type is " + fieldType, field);
+            }
+            return;
+        }
+
+        // Numeric string — valid on numeric types or Optional<NumericType>
+        if (isNumericString(value)) {
+            String checkType = isOptional ? innerType : fieldType;
+            if (!isNumericType(checkType)) {
+                messager.printMessage(Diagnostic.Kind.ERROR,
+                        "@AssertDefault(\"" + value + "\") is numeric but field type " + fieldType + " is not a numeric type", field);
+            }
+            return;
+        }
+
+        // String literal fallback — valid on String or Optional<String>
+        String checkType = isOptional ? innerType : fieldType;
+        if (!checkType.equals("java.lang.String") && !checkType.equals("String")) {
+            messager.printMessage(Diagnostic.Kind.ERROR,
+                    "@AssertDefault(\"" + value + "\") is a string literal but field type " + fieldType + " is not String", field);
+        }
+    }
+
+    private boolean isBooleanType(String type) {
+        return "java.lang.Boolean".equals(type) || "Boolean".equals(type) || "boolean".equals(type);
+    }
+
+    private boolean isNumericType(String type) {
+        return switch (type) {
+            case "int", "long", "float", "double", "short", "byte",
+                 "java.lang.Integer", "Integer",
+                 "java.lang.Long", "Long",
+                 "java.lang.Float", "Float",
+                 "java.lang.Double", "Double",
+                 "java.lang.Short", "Short",
+                 "java.lang.Byte", "Byte",
+                 "java.math.BigDecimal", "BigDecimal",
+                 "java.math.BigInteger", "BigInteger" -> true;
+            default -> false;
+        };
+    }
+
+    private boolean isNumericString(String value) {
+        try {
+            Double.parseDouble(value);
+            return true;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+
+    private String getOptionalInnerTypeString(String fieldType) {
+        int start = fieldType.indexOf('<');
+        int end = fieldType.lastIndexOf('>');
+        if (start >= 0 && end > start) {
+            return fieldType.substring(start + 1, end);
+        }
+        return "Object";
     }
 
     private boolean isGetter(ExecutableElement method) {

--- a/src/test/java/cloud/alchemy/fabut/AssertableEntityLegacyTest.java
+++ b/src/test/java/cloud/alchemy/fabut/AssertableEntityLegacyTest.java
@@ -38,7 +38,10 @@ public class AssertableEntityLegacyTest extends AbstractFabutTest {
                 value("count", 42),
                 value("description", Optional.of("desc")),
                 value("score", Optional.of(100)),
-                ignored("version"));
+                ignored("version"),
+                value("active", false),
+                value("visible", Optional.of(true)),
+                value("category", Optional.empty()));
     }
 
     @Test
@@ -51,7 +54,10 @@ public class AssertableEntityLegacyTest extends AbstractFabutTest {
                 value("count", 42),
                 value("description", Optional.empty()),
                 value("score", Optional.empty()),
-                ignored("version"));
+                ignored("version"),
+                value("active", false),
+                value("visible", Optional.of(true)),
+                value("category", Optional.empty()));
     }
 
     @Test
@@ -64,7 +70,10 @@ public class AssertableEntityLegacyTest extends AbstractFabutTest {
                 isNull("count"),
                 value("description", Optional.empty()),
                 value("score", Optional.empty()),
-                ignored("version"));
+                ignored("version"),
+                value("active", false),
+                value("visible", Optional.of(true)),
+                value("category", Optional.empty()));
     }
 
     @Test
@@ -77,7 +86,10 @@ public class AssertableEntityLegacyTest extends AbstractFabutTest {
                 notNull("count"),
                 value("description", Optional.empty()),
                 value("score", Optional.empty()),
-                ignored("version"));
+                ignored("version"),
+                value("active", false),
+                value("visible", Optional.of(true)),
+                value("category", Optional.empty()));
     }
 
     @Test
@@ -90,7 +102,10 @@ public class AssertableEntityLegacyTest extends AbstractFabutTest {
                 ignored("count"),
                 ignored("description"),
                 ignored("score"),
-                ignored("version"));
+                ignored("version"),
+                value("active", false),
+                value("visible", Optional.of(true)),
+                value("category", Optional.empty()));
     }
 
     @Test
@@ -103,7 +118,10 @@ public class AssertableEntityLegacyTest extends AbstractFabutTest {
                 value("count", 42),
                 notNull("description"),
                 notNull("score"),
-                ignored("version"));
+                ignored("version"),
+                value("active", false),
+                value("visible", Optional.of(true)),
+                value("category", Optional.empty()));
     }
 
     // ==================== Failure Cases ====================
@@ -180,7 +198,10 @@ public class AssertableEntityLegacyTest extends AbstractFabutTest {
                 ignored("count"),                 // ignored
                 value("description", Optional.of("desc")),  // Optional with value
                 value("score", Optional.empty()), // Optional empty
-                ignored("version"));
+                ignored("version"),
+                value("active", false),
+                value("visible", Optional.of(true)),
+                value("category", Optional.empty()));
     }
 
     // ==================== Internal assertObjects (for testing parity with v4 internals) ====================
@@ -220,6 +241,9 @@ public class AssertableEntityLegacyTest extends AbstractFabutTest {
                 value("count", 42),
                 value("description", Optional.empty()),
                 value("score", Optional.empty()),
-                ignored("version"));  // Must explicitly ignore in v4 API
+                ignored("version"),
+                value("active", false),
+                value("visible", Optional.of(true)),
+                value("category", Optional.empty()));  // Must explicitly ignore in v4 API
     }
 }

--- a/src/test/java/cloud/alchemy/fabut/AssertableEntityLegacyTest.java
+++ b/src/test/java/cloud/alchemy/fabut/AssertableEntityLegacyTest.java
@@ -103,9 +103,9 @@ public class AssertableEntityLegacyTest extends AbstractFabutTest {
                 ignored("description"),
                 ignored("score"),
                 ignored("version"),
-                value("active", false),
-                value("visible", Optional.of(true)),
-                value("category", Optional.empty()));
+                ignored("active"),
+                ignored("visible"),
+                ignored("category"));
     }
 
     @Test

--- a/src/test/java/cloud/alchemy/fabut/GeneratedAssertBuilderTest.java
+++ b/src/test/java/cloud/alchemy/fabut/GeneratedAssertBuilderTest.java
@@ -202,9 +202,11 @@ public class GeneratedAssertBuilderTest extends AbstractFabutTest {
         AssertableEntity entity = new AssertableEntity(1L, "test", 42, Optional.of("desc"), Optional.of(100));
 
         // Use assertCreate with all mandatory fields as parameters
-        AssertableEntityAssert.created(entity, 1L, "test", 42)
+        AssertableEntityAssert.created(entity, 1L, "test", 42, false)
                 .description_is("desc")
                 .score_is(100)
+                .visible_is(true)
+                .category_is_empty()
                 .verify();
     }
 
@@ -213,9 +215,11 @@ public class GeneratedAssertBuilderTest extends AbstractFabutTest {
         AssertableEntity entity = new AssertableEntity(1L, "test", 42, Optional.empty(), Optional.empty());
 
         // Use created with explicit Fabut and all mandatory fields
-        AssertableEntityAssert.created(this, entity, 1L, "test", 42)
+        AssertableEntityAssert.created(this, entity, 1L, "test", 42, false)
                 .description_is_empty()
                 .score_is_empty()
+                .visible_is(true)
+                .category_is_empty()
                 .verify();
     }
 
@@ -224,9 +228,11 @@ public class GeneratedAssertBuilderTest extends AbstractFabutTest {
         AssertableEntity entity = new AssertableEntity(1L, "test", 42, Optional.of("desc"), Optional.of(100));
 
         // Mandatory fields are set, optional fields can be ignored
-        AssertableEntityAssert.created(entity, 1L, "test", 42)
+        AssertableEntityAssert.created(entity, 1L, "test", 42, false)
                 .description_is_ignored()
                 .score_is_ignored()
+                .visible_is_ignored()
+                .category_is_ignored()
                 .verify();
     }
 
@@ -236,9 +242,11 @@ public class GeneratedAssertBuilderTest extends AbstractFabutTest {
 
         // Mismatch in mandatory field should fail
         assertThrows(AssertionFailedError.class, () ->
-                AssertableEntityAssert.created(entity, 1L, "expected", 42)
+                AssertableEntityAssert.created(entity, 1L, "expected", 42, false)
                         .description_is_empty()
                         .score_is_empty()
+                        .visible_is(true)
+                        .category_is_empty()
                         .verify()
         );
     }
@@ -323,6 +331,146 @@ public class GeneratedAssertBuilderTest extends AbstractFabutTest {
                 .score_is_empty()
                 .verify();
         // No versionIs() call needed - field is ignored
+    }
+
+    // ==================== @AssertDefault Tests ====================
+
+    @Test
+    public void testAssertDefault_CreatedWithDefaults_Success() {
+        // All defaults match constructor values: active=false, visible=Optional.of(true), category=Optional.empty()
+        AssertableEntity entity = new AssertableEntity(1L, "test", 42, Optional.empty(), Optional.empty());
+
+        AssertableEntityAssert.created(this, entity)
+                .id_is(1L)
+                .name_is("test")
+                .count_is(42)
+                .description_is_empty()
+                .score_is_empty()
+                // active, visible, category auto-asserted by defaults
+                .verify();
+    }
+
+    @Test
+    public void testAssertDefault_BooleanMismatch_Fails() {
+        AssertableEntity entity = new AssertableEntity(1L, "test", 42, Optional.empty(), Optional.empty());
+        entity.setActive(true);  // Default expects false
+
+        assertThrows(AssertionFailedError.class, () ->
+                AssertableEntityAssert.created(this, entity)
+                        .id_is(1L)
+                        .name_is("test")
+                        .count_is(42)
+                        .description_is_empty()
+                        .score_is_empty()
+                        .verify()
+        );
+    }
+
+    @Test
+    public void testAssertDefault_OptionalBooleanMismatch_Fails() {
+        AssertableEntity entity = new AssertableEntity(1L, "test", 42, Optional.empty(), Optional.empty());
+        entity.setVisible(Optional.of(false));  // Default expects true
+
+        assertThrows(AssertionFailedError.class, () ->
+                AssertableEntityAssert.created(this, entity)
+                        .id_is(1L)
+                        .name_is("test")
+                        .count_is(42)
+                        .description_is_empty()
+                        .score_is_empty()
+                        .verify()
+        );
+    }
+
+    @Test
+    public void testAssertDefault_OptionalEmptyMismatch_Fails() {
+        AssertableEntity entity = new AssertableEntity(1L, "test", 42, Optional.empty(), Optional.empty());
+        entity.setCategory(Optional.of("X"));  // Default expects empty
+
+        assertThrows(AssertionFailedError.class, () ->
+                AssertableEntityAssert.created(this, entity)
+                        .id_is(1L)
+                        .name_is("test")
+                        .count_is(42)
+                        .description_is_empty()
+                        .score_is_empty()
+                        .verify()
+        );
+    }
+
+    @Test
+    public void testAssertDefault_ExplicitOverride_Boolean_Success() {
+        AssertableEntity entity = new AssertableEntity(1L, "test", 42, Optional.empty(), Optional.empty());
+        entity.setActive(true);
+
+        AssertableEntityAssert.created(this, entity)
+                .id_is(1L)
+                .name_is("test")
+                .count_is(42)
+                .description_is_empty()
+                .score_is_empty()
+                .active_is(true)  // Override default
+                .verify();
+    }
+
+    @Test
+    public void testAssertDefault_ExplicitOverride_OptionalBoolean_Success() {
+        AssertableEntity entity = new AssertableEntity(1L, "test", 42, Optional.empty(), Optional.empty());
+        entity.setVisible(Optional.of(false));
+
+        AssertableEntityAssert.created(this, entity)
+                .id_is(1L)
+                .name_is("test")
+                .count_is(42)
+                .description_is_empty()
+                .score_is_empty()
+                .visible_is(false)  // Override default
+                .verify();
+    }
+
+    @Test
+    public void testAssertDefault_ExplicitOverride_OptionalString_Success() {
+        AssertableEntity entity = new AssertableEntity(1L, "test", 42, Optional.empty(), Optional.empty());
+        entity.setCategory(Optional.of("X"));
+
+        AssertableEntityAssert.created(this, entity)
+                .id_is(1L)
+                .name_is("test")
+                .count_is(42)
+                .description_is_empty()
+                .score_is_empty()
+                .category_is("X")  // Override default
+                .verify();
+    }
+
+    @Test
+    public void testAssertDefault_IgnoredOverridesDefault_Success() {
+        AssertableEntity entity = new AssertableEntity(1L, "test", 42, Optional.empty(), Optional.empty());
+        entity.setActive(true);  // Doesn't matter — field is ignored
+
+        AssertableEntityAssert.created(this, entity)
+                .id_is(1L)
+                .name_is("test")
+                .count_is(42)
+                .description_is_empty()
+                .score_is_empty()
+                .active_is_ignored()  // Suppresses default assertion
+                .visible_is_ignored()
+                .category_is_ignored()
+                .verify();
+    }
+
+    @Test
+    public void testAssertDefault_GroupMethodWithDefaults_Success() {
+        AssertableEntity entity = new AssertableEntity(1L, "test", 42, Optional.empty(), Optional.empty());
+
+        // createdKey only sets id and name — defaults for active, visible, category auto-asserted
+        AssertableEntityAssert.createdKey(entity, 1L, "test")
+                .count_is(42)
+                .description_is_empty()
+                .score_is_empty()
+                // active, visible, category auto-asserted by defaults
+                .verify();
     }
 
     // ==================== Auto-Verify ====================

--- a/src/test/java/cloud/alchemy/fabut/diff/DiffTest.java
+++ b/src/test/java/cloud/alchemy/fabut/diff/DiffTest.java
@@ -28,7 +28,7 @@ class DiffTest {
         // Then
         assertFalse(diff.hasChanges());
         assertEquals(0, diff.changeCount());
-        assertEquals(5, diff.getAllChanges().size());
+        assertEquals(8, diff.getAllChanges().size());
         assertTrue(diff.getChangedFields().isEmpty());
     }
 

--- a/src/test/java/cloud/alchemy/fabut/model/AssertableEntity.java
+++ b/src/test/java/cloud/alchemy/fabut/model/AssertableEntity.java
@@ -1,5 +1,6 @@
 package cloud.alchemy.fabut.model;
 
+import cloud.alchemy.fabut.annotation.AssertDefault;
 import cloud.alchemy.fabut.annotation.AssertGroup;
 import cloud.alchemy.fabut.annotation.Assertable;
 
@@ -28,9 +29,21 @@ public class AssertableEntity {
     private Optional<Integer> score;
     private Long version;
 
+    @AssertDefault("false")
+    private Boolean active;
+
+    @AssertDefault("true")
+    private Optional<Boolean> visible;
+
+    @AssertDefault("empty")
+    private Optional<String> category;
+
     public AssertableEntity() {
         this.description = Optional.empty();
         this.score = Optional.empty();
+        this.active = false;
+        this.visible = Optional.of(true);
+        this.category = Optional.empty();
     }
 
     public AssertableEntity(Long id, String name, Integer count, Optional<String> description, Optional<Integer> score) {
@@ -39,6 +52,9 @@ public class AssertableEntity {
         this.count = count;
         this.description = description;
         this.score = score;
+        this.active = false;
+        this.visible = Optional.of(true);
+        this.category = Optional.empty();
     }
 
     public Long getId() {
@@ -87,5 +103,29 @@ public class AssertableEntity {
 
     public void setVersion(Long version) {
         this.version = version;
+    }
+
+    public Boolean getActive() {
+        return active;
+    }
+
+    public void setActive(Boolean active) {
+        this.active = active;
+    }
+
+    public Optional<Boolean> getVisible() {
+        return visible;
+    }
+
+    public void setVisible(Optional<Boolean> visible) {
+        this.visible = visible;
+    }
+
+    public Optional<String> getCategory() {
+        return category;
+    }
+
+    public void setCategory(Optional<String> category) {
+        this.category = category;
     }
 }

--- a/src/test/java/cloud/alchemy/fabut/processor/AssertableProcessorTest.java
+++ b/src/test/java/cloud/alchemy/fabut/processor/AssertableProcessorTest.java
@@ -8,6 +8,7 @@ import cloud.alchemy.fabut.model.AssertableEntityDiff;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
@@ -218,7 +219,7 @@ public class AssertableProcessorTest extends Fabut {
 
         assertTrue(diff.hasChanges());
         // All fields should show as SET (from null to value)
-        assertEquals(5, diff.changeCount());
+        assertEquals(8, diff.changeCount());
     }
 
     @Test
@@ -229,7 +230,7 @@ public class AssertableProcessorTest extends Fabut {
 
         assertTrue(diff.hasChanges());
         // All fields should show as CLEARED (from value to null)
-        assertEquals(5, diff.changeCount());
+        assertEquals(8, diff.changeCount());
     }
 
     @Test
@@ -324,5 +325,50 @@ public class AssertableProcessorTest extends Fabut {
         // score_is(Integer) is the overloaded convenience method (inner type of Optional<Integer>)
         Method scoreIsInteger = AssertableEntityAssert.class.getMethod("score_is", Integer.class);
         assertNotNull(scoreIsInteger);
+    }
+
+    // ==================== @AssertDefault Code Generation Tests ====================
+
+    @Test
+    public void testAssertDefaultGeneratesExplicitFieldsSet() throws NoSuchFieldException {
+        // explicitFields should be a private final Set<String>
+        Field explicitFields = AssertableEntityAssert.class.getDeclaredField("explicitFields");
+        assertTrue(Modifier.isPrivate(explicitFields.getModifiers()));
+        assertTrue(Modifier.isFinal(explicitFields.getModifiers()));
+        assertEquals(Set.class, explicitFields.getType());
+    }
+
+    @Test
+    public void testAssertDefaultFieldMethodsExist() {
+        Set<String> methodNames = Arrays.stream(AssertableEntityAssert.class.getMethods())
+                .map(Method::getName)
+                .collect(Collectors.toSet());
+
+        // active (Boolean with @AssertDefault("false"))
+        assertTrue(methodNames.contains("active_is"), "Should have active_is method");
+        assertTrue(methodNames.contains("active_is_null"), "Should have active_is_null method");
+        assertTrue(methodNames.contains("active_is_ignored"), "Should have active_is_ignored method");
+
+        // visible (Optional<Boolean> with @AssertDefault("true"))
+        assertTrue(methodNames.contains("visible_is"), "Should have visible_is method");
+        assertTrue(methodNames.contains("visible_is_empty"), "Should have visible_is_empty method");
+        assertTrue(methodNames.contains("visible_is_not_empty"), "Should have visible_is_not_empty method");
+
+        // category (Optional<String> with @AssertDefault("empty"))
+        assertTrue(methodNames.contains("category_is"), "Should have category_is method");
+        assertTrue(methodNames.contains("category_is_empty"), "Should have category_is_empty method");
+        assertTrue(methodNames.contains("category_is_not_empty"), "Should have category_is_not_empty method");
+    }
+
+    @Test
+    public void testAssertDefaultOptionalBooleanHasConvenienceOverload() throws NoSuchMethodException {
+        // visible_is(Boolean) — convenience overload that wraps in Optional.of()
+        Method visibleIsBoolean = AssertableEntityAssert.class.getMethod("visible_is", Boolean.class);
+        assertNotNull(visibleIsBoolean);
+        assertEquals(AssertableEntityAssert.class, visibleIsBoolean.getReturnType());
+
+        // visible_is(Optional) — full type overload
+        Method visibleIsOptional = AssertableEntityAssert.class.getMethod("visible_is", Optional.class);
+        assertNotNull(visibleIsOptional);
     }
 }


### PR DESCRIPTION
## Summary

- Adds `@AssertDefault` field-level annotation that declares the default expected value for a field in generated assertion builders
- When `verify()` is called on a `created()` assertion and the annotated field has not been explicitly asserted, the default value is automatically applied
- Zero overhead for entities without `@AssertDefault` — no extra fields or tracking code generated

## Motivation

Entity fields like `usedInCoa` on `PropertyValue` almost always have the same value (`false`) when newly created. Currently, every `created()` assertion must explicitly state `.usedInCoa_is(false)` — this appears **48 times** across the test codebase for this single field. With `@AssertDefault`, the annotation on the entity field eliminates this boilerplate entirely.

## Usage

### On the entity field:
```java
@Assertable
public class PropertyValue {
    @AssertDefault("false")
    @Column(name = "usedInCoa")
    private Boolean usedInCoa;
}
```

### In tests:
```java
// Before: must explicitly assert the default value every time
PropertyValueAssert.created(pv).usedInCoa_is(false).verify();

// After: default is automatic, only assert when different
PropertyValueAssert.created(pv).verify();

// Explicit override still works — default is skipped
PropertyValueAssert.created(pv).usedInCoa_is(true).verify();
```

## Supported default values

| `@AssertDefault` value | Field type | Generated assertion |
|---|---|---|
| `"true"` / `"false"` | `Boolean` | `fabut.value("field", false)` |
| `"true"` / `"false"` | `Optional<Boolean>` | `fabut.value("field", Optional.of(false))` |
| `"empty"` | `Optional<?>` | `fabut.isEmpty("field")` |
| `"null"` | any | `fabut.isNull("field")` |
| numeric (e.g. `"0"`, `"42"`) | numeric | `fabut.value("field", 0)` |
| other string | `String` | `fabut.value("field", "value")` |

## Design decisions

- **Defaults only apply to `created()` assertions** (non-snapshot). For `updated()`, the snapshot comparison already handles unchanged fields — injecting a default there would override the snapshot check and could mask bugs.
- **Explicit assertion always wins.** Any call to `_is()`, `_is_null()`, `_is_ignored()`, `_is_empty()`, or `_is_not_empty()` marks the field as explicit and the default is skipped.
- **Conditional code generation.** The `explicitFields` Set and tracking logic are only generated when at least one field has `@AssertDefault`. Entities without defaults produce identical generated code to before — no behavioral change, no overhead.
- **Annotation is `SOURCE` retention** — available to the processor at compile time, not present in bytecode.

## Implementation

### New file: `AssertDefault.java`
Field-level annotation with a single `String value()` attribute.

### Changes to `AssertableProcessor.java`
1. `collectFieldDefaults()` — scans field declarations for `@AssertDefault`, builds a `fieldName → defaultValue` map
2. `FieldInfo` record — extended with `defaultValue` (nullable)
3. `generateBuilderClass()` — conditionally generates `Set<String> explicitFields` field and `HashSet`/`Set` imports
4. `generateFieldMethods()` — every `_is*` method adds the field name to `explicitFields` (only when defaults exist)
5. `verify()` — for `created()` assertions, iterates fields with defaults and adds the default assertion for any field not in `explicitFields`
6. `generateDefaultPropertyExpression()` — converts the annotation's string value to the appropriate Java expression based on field type (Boolean, Optional, numeric, String)
7. Group methods and parameterized `created()`/`updated()` methods also track explicit fields

## Test plan

- [x] Fabut compiles successfully (`mvn compile`)
- [x] AlchemyCloud compiles with `@AssertDefault("false")` on `PropertyValue.usedInCoa` (`./gradlew :core:compileJava`)
- [x] Test code compiles (`./gradlew :core:compileTestJava`)
- [x] `PropertiesApi_UpdatePropertyValueUseInCertificateOfAnalysisTest` passes with the annotation in place
- [ ] Verify generated code for entities without `@AssertDefault` is unchanged
- [ ] Add unit tests for `@AssertDefault` with various value types

🤖 Generated with [Claude Code](https://claude.com/claude-code)